### PR TITLE
Feat #15#16, Fix #17

### DIFF
--- a/src/main/java/io/yapix/action/AbstractionUploadAction.java
+++ b/src/main/java/io/yapix/action/AbstractionUploadAction.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,7 +41,7 @@ public abstract class AbstractionUploadAction extends AbstractAction {
      * @param afterAction 所有接口列表处理完毕后的回调执行，用于关闭资源
      */
     protected <T> void handleUploadAsync(Project project, List<Api> apis, Function<Api, ApiUploadResult> apiConsumer,
-            Supplier<?> afterAction) {
+                                         Supplier<?> afterAction) {
         // 异步处理
         ProgressManager.getInstance().run(new Task.Backgroundable(project, DefaultConstants.NAME) {
             @Override
@@ -83,10 +85,13 @@ public abstract class AbstractionUploadAction extends AbstractAction {
                 } catch (InterruptedException e) {
                     // ignore
                 } finally {
-                    Set<String> categories = urls.stream().collect(Collectors.groupingBy(ApiUploadResult::getCategoryUrl)).keySet();
-                    notifyInfo("Upload result", format("categories(%d) - apis(%d/%d)", categories.size(), urls.size(), apis.size()));
-                    for (String url : categories) {
+                    if (urls.size() == 1){
+                        String url = urls.get(0).getApiUrl();
                         notifyInfo("Upload successful", format("<a href=\"%s\">%s</a>", url, url));
+                    } else {
+                        Map<String, List<ApiUploadResult>> categories = urls.stream().collect(Collectors.groupingBy(ApiUploadResult::getCategoryUrl));
+                        notifyInfo("Upload result", format("categories(%d) - apis(%d/%d)", categories.size(), urls.size(), apis.size()));
+                        categories.keySet().forEach(url -> notifyInfo("Upload successful", format("<a href=\"%s\">%s</a>", url, url)));
                     }
                     threadPool.shutdown();
                     afterAction.get();

--- a/src/main/java/io/yapix/action/AbstractionUploadAction.java
+++ b/src/main/java/io/yapix/action/AbstractionUploadAction.java
@@ -1,7 +1,6 @@
 package io.yapix.action;
 
-import static io.yapix.base.util.NotificationUtils.notifyError;
-import static io.yapix.base.util.NotificationUtils.notifyInfo;
+import static io.yapix.base.util.NotificationUtils.*;
 import static java.lang.String.format;
 
 import com.google.common.collect.Lists;
@@ -13,8 +12,8 @@ import com.intellij.openapi.project.Project;
 import io.yapix.base.util.ConcurrentUtils;
 import io.yapix.config.DefaultConstants;
 import io.yapix.model.Api;
-import java.util.List;
-import java.util.Objects;
+
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -54,7 +53,7 @@ public abstract class AbstractionUploadAction extends AbstractAction {
                 AtomicInteger count = new AtomicInteger();
                 AtomicDouble fraction = new AtomicDouble();
 
-                List<ApiUploadResult> urls = null;
+                List<ApiUploadResult> urls = new ArrayList<>();
                 try {
                     List<Future<ApiUploadResult>> futures = Lists.newArrayListWithExpectedSize(apis.size());
                     for (int i = 0; i < apis.size() && !indicator.isCanceled(); i++) {
@@ -84,9 +83,9 @@ public abstract class AbstractionUploadAction extends AbstractAction {
                 } catch (InterruptedException e) {
                     // ignore
                 } finally {
-                    if (urls != null && urls.size() > 0) {
-                        ApiUploadResult uploadResult = urls.get(0);
-                        String url = urls.size() == 1 ? uploadResult.getApiUrl() : uploadResult.getCategoryUrl();
+                    Set<String> categories = urls.stream().collect(Collectors.groupingBy(ApiUploadResult::getCategoryUrl)).keySet();
+                    notifyInfo("Upload result", format("categories(%d) - apis(%d/%d)", categories.size(), urls.size(), apis.size()));
+                    for (String url : categories) {
                         notifyInfo("Upload successful", format("<a href=\"%s\">%s</a>", url, url));
                     }
                     threadPool.shutdown();

--- a/src/main/java/io/yapix/action/YapixActionGroup.java
+++ b/src/main/java/io/yapix/action/YapixActionGroup.java
@@ -14,12 +14,11 @@ public class YapixActionGroup extends DefaultActionGroup {
 
     @Override
     public void update(@NotNull AnActionEvent event) {
-        boolean visible = true;
+        boolean visible = false;
         // 编辑器上下文非java文件不展示
-        Editor editor = event.getDataContext().getData(CommonDataKeys.EDITOR);
         VirtualFile file = event.getDataContext().getData(CommonDataKeys.VIRTUAL_FILE);
-        if (editor != null && file != null && !"java".equals(file.getExtension())) {
-            visible = false;
+        if (file != null){
+            visible = file.isDirectory() || "java".equals(file.getExtension());
         }
         event.getPresentation().setVisible(visible);
     }

--- a/src/main/java/io/yapix/base/util/NotificationUtils.java
+++ b/src/main/java/io/yapix/base/util/NotificationUtils.java
@@ -38,6 +38,15 @@ public final class NotificationUtils {
         Notification notification = DEFAULT_GROUP.createNotification(content, NotificationType.WARNING);
         Notifications.Bus.notify(notification);
     }
+    
+    /**
+     * 提示警告消息
+     */
+    public static void notifyWarning(String title, String content) {
+        Notification notification = DEFAULT_GROUP.createNotification(title, content, NotificationType.WARNING, null);
+        Notifications.Bus.notify(notification);
+    }
+    
 
     /**
      * 提示错误消息

--- a/src/main/java/io/yapix/model/Property.java
+++ b/src/main/java/io/yapix/model/Property.java
@@ -110,6 +110,15 @@ public class Property {
         if (StringUtils.isNotEmpty(custom.getMock())) {
             this.mock = custom.getMock();
         }
+        if (custom.getMaxItems() != null){
+            this.maxItems = custom.getMaxItems();
+        }
+        if (custom.getMinItems() != null){
+            this.minItems = custom.getMinItems();
+        }
+        if (custom.getUniqueItems() != null){
+            this.uniqueItems = custom.getUniqueItems();
+        }
     }
 
     /**

--- a/src/main/java/io/yapix/parse/constant/DocumentTags.java
+++ b/src/main/java/io/yapix/parse/constant/DocumentTags.java
@@ -19,4 +19,5 @@ public interface DocumentTags {
 
     String Ignore = "ignore";
 
+    String See = "see";
 }

--- a/src/main/java/io/yapix/parse/parser/KernelParser.java
+++ b/src/main/java/io/yapix/parse/parser/KernelParser.java
@@ -1,32 +1,26 @@
 package io.yapix.parse.parser;
 
+import static io.yapix.base.util.NotificationUtils.notifyWarning;
 import static io.yapix.parse.util.PsiGenericUtils.splitTypeAndGenericPair;
+import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiArrayType;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiType;
+import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTypesUtil;
 import io.yapix.config.BeanCustom;
 import io.yapix.config.YapixConfig;
 import io.yapix.model.DataTypes;
 import io.yapix.model.Property;
+import io.yapix.parse.constant.DocumentTags;
 import io.yapix.parse.constant.JavaConstants;
-import io.yapix.parse.util.PsiFieldUtils;
-import io.yapix.parse.util.PsiGenericUtils;
-import io.yapix.parse.util.PsiTypeUtils;
-import io.yapix.parse.util.PsiUtils;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import io.yapix.parse.util.*;
+
+import java.util.*;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -150,6 +144,28 @@ public class KernelParser {
         BeanCustom beanCustom = getBeanCustomSettings(type);
 
         Map<String, Property> properties = new LinkedHashMap<>();
+
+        // 针对接口/实体类, 检查是否存在@see引用
+        for (String typeName : PsiDocCommentUtils.getTagTextSet(psiClass, DocumentTags.See)) {
+            // 优先根据全限定名获取引用类, 其次根据非限定名(短名)获取.
+            // [note] 建议用户尽量使用全限定名, 短名容易出现重名冲突.
+            // 其实可以通过获取当前类的import作filter.
+            // 但既然用户使用javadoc, 就应该对输入作严格规范, 而非对插件输出作强要求.
+            PsiClass refPsiClass = Optional.ofNullable(PsiUtils.findPsiClass(project, module, typeName))
+                    .orElse(PsiUtils.findPsiClassByShortName(project, module, typeName));
+
+            // 引用类必须跟当前类存在派生关系(适用于接口和实体类)
+            if (refPsiClass == null || !refPsiClass.isInheritor(psiClass, true)){
+                notifyWarning("Parse skipped", format("%s @see %s", type, typeName));
+                continue;
+            }
+
+            Optional.of(PsiTypesUtil.getClassType(refPsiClass))
+                    .map(it -> doParseType(it, it.getCanonicalText(), chains))
+                    .map(Property::getProperties)
+                    .ifPresent(properties::putAll);
+        }
+
         if (psiClass.isInterface()) {
             // 接口类型
             PsiMethod[] methods = PsiUtils.getGetterMethods(psiClass);

--- a/src/main/java/io/yapix/parse/util/PropertiesLoader.java
+++ b/src/main/java/io/yapix/parse/util/PropertiesLoader.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * properties文件加载，内部会缓存.
  */
-public class PropertiesLoader {
+public class PropertiesLoader  {
 
     private static final Map<String, Properties> cache = new ConcurrentHashMap<>();
 

--- a/src/main/java/io/yapix/parse/util/PsiDocCommentUtils.java
+++ b/src/main/java/io/yapix/parse/util/PsiDocCommentUtils.java
@@ -10,6 +10,8 @@ import io.yapix.parse.constant.DocumentTags;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * PsiDocComment相关工具类
@@ -21,9 +23,8 @@ public class PsiDocCommentUtils {
 
 
     /**
-     * 获取获取标记自定字段名
+     * 获取标记自定义字段名(包括字段描述)
      *
-     * @param element sdfdsf
      */
     public static Map<String, String> getTagParamTextMap(PsiJavaDocumentedElement element) {
         Map<String, String> map = new HashMap<>();
@@ -37,6 +38,28 @@ public class PsiDocCommentUtils {
             }
         }
         return map;
+    }
+
+    /**
+     * 获取标记自定义字段名(不包括字段描述)
+     * @param tag 实例变量类型为接口类/实体类  可通过@see 来获取扁平后的字段
+     *
+     * /**
+     *   * @see SubInterfaceImpl {field1, field2}
+     *   * @see SubxInterfaceImpl {field3, field4, field5}
+     *   *\/
+     * interface BaseInterface {}
+     *
+     * BaseInterface {field1, field2, field3, ...}
+     * 至于如何区分field1,field2,field3隶属于哪个实现类, 是用户写desc需要考量的, 而非插件程序逻辑.
+     *
+     */
+    public static Set<String> getTagTextSet(PsiJavaDocumentedElement element, String tag){
+        return Arrays.stream(findTagsByName(element, tag))
+                .map(PsiDocTag::getDataElements)
+                .filter(it -> it.length >= 1)
+                .map(it -> it[0].getText().trim())
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/io/yapix/process/curl/CopyAsCurlAction.java
+++ b/src/main/java/io/yapix/process/curl/CopyAsCurlAction.java
@@ -8,6 +8,8 @@ import io.yapix.model.Api;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
+import static io.yapix.base.util.NotificationUtils.*;
+
 /**
  * 复制成Curl字符串处理器
  */
@@ -18,10 +20,12 @@ public class CopyAsCurlAction extends AbstractAction {
     @Override
     public void handle(AnActionEvent event, YapixConfig config, List<Api> apis) {
         if (apis.size() != 1) {
+            notifyWarning("Copy as cURL", "only support single api, please choose method in editor");
             return;
         }
         String curl = new CurlGenerator().generate(apis.get(0));
         ClipboardUtils.setClipboard(curl);
+        notifyInfo("Copy as cURL", "copied to clipboard");
     }
 
     @Override

--- a/src/main/java/io/yapix/process/markdown/CopyAsMarkdownAction.java
+++ b/src/main/java/io/yapix/process/markdown/CopyAsMarkdownAction.java
@@ -20,7 +20,7 @@ public class CopyAsMarkdownAction extends AbstractAction {
     public void handle(AnActionEvent event, YapixConfig config, List<Api> apis) {
         String markdown = new MarkdownGenerator().generate(apis);
         ClipboardUtils.setClipboard(markdown);
-        NotificationUtils.notifyInfo("Copied");
+        NotificationUtils.notifyInfo("Copy as Markdown", "copied to clipboard");
     }
 
     @Override

--- a/src/main/java/io/yapix/process/markdown/MarkdownGenerator.java
+++ b/src/main/java/io/yapix/process/markdown/MarkdownGenerator.java
@@ -3,11 +3,11 @@ package io.yapix.process.markdown;
 import io.yapix.model.Api;
 import io.yapix.model.ParameterIn;
 import io.yapix.model.Property;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -94,7 +94,11 @@ public class MarkdownGenerator {
         markdown.append("| 名称 | 必选 | 类型 | 默认值 | 描述 |").append("\n");
         markdown.append("| - | - | - | - | - |").append("\n");
         if (property.isObjectType()) {
-            property.getProperties().values().forEach(p -> markdown.append(propertyRowSnippets(p, 1)));
+            Optional.ofNullable(property.getProperties())
+                    .map(Map::values)
+                    .map(Collection::stream)
+                    .orElseGet(Stream::empty)
+                    .forEach(p -> markdown.append(propertyRowSnippets(p, 1)));
         } else {
             markdown.append(propertyRowSnippets(property, 1));
         }


### PR DESCRIPTION
- #16 
- #15 
- #17
- chore: complete commit#35ab82ab 
- chore: copy as cURL/markdown complete log
- chore: via scanning package to sync yapi, it include multi-categories, so it's better to upload url which group by category as unit. btw, it's necessary support more detail in upload info(category#size, sc/total, etc).
**(append) when just upload single api, it should show api-url only.**